### PR TITLE
[prop-types] v4.0.0

### DIFF
--- a/deprecated-react-native-prop-types/CHANGELOG.md
+++ b/deprecated-react-native-prop-types/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 4.0.0 / 2022-12-13
+
+- Compatible with React Native 0.72
+- Updated dependency from `@react-native/normalize-color` to 
+  `@react-native/normalize-colors` due to upstream renaming of such dependency, 
+  needed for compatibility with 0.72
+- This major bump is needed as `react-native@0.71` will still use 
+  `@react-native/normalize-color` and we want users of 0.71 to continue depending 
+  on 3.0.1.
+
 # 3.0.1 / 2022-12-02
 
 - Compatible with React Native 0.71

--- a/deprecated-react-native-prop-types/DeprecatedColorPropType.js
+++ b/deprecated-react-native-prop-types/DeprecatedColorPropType.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const normalizeColor = require('@react-native/normalize-color');
+const normalizeColor = require('@react-native/normalize-colors');
 
 /**
  * @see facebook/react-native/Libraries/StyleSheet/StyleSheetTypes.js

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -1,11 +1,11 @@
 {
   "name": "deprecated-react-native-prop-types",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Deprecated prop-types from React Native.",
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",
   "dependencies": {
-    "@react-native/normalize-color": "*",
+    "@react-native/normalize-colors": "*",
     "invariant": "*",
     "prop-types": "*"
   },

--- a/deprecated-react-native-prop-types/yarn.lock
+++ b/deprecated-react-native-prop-types/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@react-native/normalize-color@*":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-color/-/normalize-color-2.0.0.tgz#da955909432474a9a0fe1cbffc66576a0447f567"
-  integrity sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw==
+"@react-native/normalize-colors@*":
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.72.0.tgz#14294b7ed3c1d92176d2a00df48456e8d7d62212"
+  integrity sha512-285lfdqSXaqKuBbbtP9qL2tDrfxdOFtIMvkKadtleRQkdOxx+uzGvFr82KHmc/sSiMtfXGp7JnFYWVh4sFl7Yw==
 
 invariant@*:
   version "2.2.4"


### PR DESCRIPTION
Upstream we renamed `@react-native/normalize-color` to `@react-native/normalize-colors`.
On nightlies we got a report that this is causing a package clash:
https://github.com/reactwg/react-native-releases/discussions/41#discussioncomment-4387776

This is needed for 0.72 and for nightlies.