### PR TITLE
feat: Add inset logical properties

### DIFF
--- a/deprecated-react-native-prop-types/DeprecatedLayoutPropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedLayoutPropTypes.js
@@ -69,6 +69,13 @@ const DeprecatedLayoutPropTypes = {
   flexWrap: PropTypes.oneOf(['nowrap', 'wrap', 'wrap-reverse']),
   gap: PropTypes.number,
   height: DimensionValuePropType,
+  inset: DimensionValuePropType,
+  insetBlock: DimensionValuePropType,
+  insetBlockEnd: DimensionValuePropType,
+  insetBlockStart: DimensionValuePropType,
+  insetInline: DimensionValuePropType,
+  insetInlineEnd: DimensionValuePropType,
+  insetInlineStart: DimensionValuePropType,
   justifyContent: PropTypes.oneOf([
     'center',
     'flex-end',


### PR DESCRIPTION
This PR updates the DeprecatedLayoutPropTypes to include the inset logical properties introduced by https://github.com/facebook/react-native/commit/9669c10afceef65626c82149210afc07d47df98b.