### PR TITLE
adding accessibilitySpan PropType to DeprecatedTextPropTypes

### DIFF
--- a/deprecated-react-native-prop-types/DeprecatedTextPropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedTextPropTypes.js
@@ -42,12 +42,12 @@ const DeprecatedTextPropTypes = {
   accessibilityLanguage: PropTypes.string,
   accessibilityRole: AccessibilityRolePropType,
   accessibilitySpan: PropTypes.oneOf([
-    | 'none'
-    | 'cardinal'
-    | 'ordinal'
-    | 'measure'
-    | 'telephone'
-    | 'verbatim'
+    'none',
+    'cardinal',
+    'ordinal',
+    'measure',
+    'telephone',
+    'verbatim',
   ]),
   accessibilityState: AccessibilityStatePropType,
   accessible: PropTypes.bool,


### PR DESCRIPTION
The original PR is under review https://github.com/facebook/react-native/pull/35130

based on the comment https://github.com/facebook/react-native/pull/35130#issuecomment-1414330273, the prop accessibilitySpan was separated from accessibilityRole

Related https://github.com/facebook/react-native-deprecated-modules/pull/16