### PR TITLE
adding accessibilityError prop types

### DIFF
--- a/deprecated-react-native-prop-types/DeprecatedTextInputPropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedTextInputPropTypes.js
@@ -28,6 +28,8 @@ const DataDetectorTypes = [
  */
 const DeprecatedTextInputPropTypes = {
   ...DeprecatedViewPropTypes,
+  accessibilityErrorMessage: PropTypes.string,
+  accessibilityInvalid: PropTypes.bool,
   allowFontScaling: PropTypes.bool,
   autoCapitalize: PropTypes.oneOf(['none', 'sentences', 'words', 'characters']),
   autoComplete: PropTypes.oneOf([


### PR DESCRIPTION
for [1/2 TextInput accessibilityErrorMessage (Talkback, Android) #33468](https://github.com/facebook/react-native/pull/33468) and [2/2 TextInput accessibilityErrorMessage (VoiceOver, iOS) #35908](https://github.com/facebook/react-native/pull/35908)