### PR TITLE
Add Flow library definitions to `*-listview` and `*-prop-types`

### DIFF
--- a/deprecated-react-native-listview/CHANGELOG.md
+++ b/deprecated-react-native-listview/CHANGELOG.md
@@ -1,3 +1,3 @@
-# Next
+# 0.0.9 / 2023-07-28
 
 - Added essential Flow library definitions

--- a/deprecated-react-native-listview/CHANGELOG.md
+++ b/deprecated-react-native-listview/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Next
+
+- Added essential Flow library definitions

--- a/deprecated-react-native-listview/ListViewDataSource.js.flow
+++ b/deprecated-react-native-listview/ListViewDataSource.js.flow
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+declare export default class ListViewDataSource {
+  constructor(params: any): ListViewDataSource;
+  cloneWithRows(
+    dataBlob: $ReadOnlyArray<any> | {+[key: string]: any},
+    rowIdentities: ?$ReadOnlyArray<string>,
+  ): ListViewDataSource;
+  cloneWithRowsAndSections(
+    dataBlob: any,
+    sectionIdentities: ?Array<string>,
+    rowIdentities: ?Array<Array<string>>,
+  ): ListViewDataSource;
+  getRowCount(): number;
+  getRowAndSectionCount(): number;
+  rowShouldUpdate(sectionIndex: number, rowIndex: number): boolean;
+  getRowData(sectionIndex: number, rowIndex: number): any;
+  getRowIDForFlatIndex(index: number): ?string;
+  getSectionIDForFlatIndex(index: number): ?string;
+  getSectionLengths(): Array<number>;
+  sectionHeaderShouldUpdate(sectionIndex: number): boolean;
+  getSectionHeaderData(sectionIndex: number): any;
+  rowIdentities: Array<Array<string>>;
+  sectionIdentities: Array<string>;
+}

--- a/deprecated-react-native-listview/index.js.flow
+++ b/deprecated-react-native-listview/index.js.flow
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type ListViewDataSource from './ListViewDataSource';
+
+declare export default class ListView extends React$Component<any> {
+  static DataSource: Class<ListViewDataSource>;
+  setNativeProps(props: Object): any;
+  flashScrollIndicators(): any;
+  getScrollResponder(): any;
+  getScrollableNode(): any;
+  getMetrics(): Object;
+  scrollTo(...args: Array<mixed>): any;
+  scrollToEnd(options?: ?{animated?: ?boolean}): any;
+}

--- a/deprecated-react-native-listview/package.json
+++ b/deprecated-react-native-listview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deprecated-react-native-listview",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "This package contains the deprecated ListView module.",
   "license": "MIT",
   "repository": {

--- a/deprecated-react-native-prop-types/CHANGELOG.md
+++ b/deprecated-react-native-prop-types/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 4.2.1 / 2023-07-28
 
 - Added `@flow` so all modules can be imported without suppressing [untyped-import]
 

--- a/deprecated-react-native-prop-types/CHANGELOG.md
+++ b/deprecated-react-native-prop-types/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- Added `@flow` so all modules can be imported without suppressing [untyped-import]
+
 # 4.2.0 / 2023-07-18
 
 - Add iOS 17 textContentType types (https://github.com/facebook/react-native-deprecated-modules/pull/23)

--- a/deprecated-react-native-prop-types/DeprecatedColorPropType.js
+++ b/deprecated-react-native-prop-types/DeprecatedColorPropType.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedEdgeInsetsPropType.js
+++ b/deprecated-react-native-prop-types/DeprecatedEdgeInsetsPropType.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedImagePropType.js
+++ b/deprecated-react-native-prop-types/DeprecatedImagePropType.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedImageSourcePropType.js
+++ b/deprecated-react-native-prop-types/DeprecatedImageSourcePropType.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedImageStylePropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedImageStylePropTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedLayoutPropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedLayoutPropTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedPointPropType.js
+++ b/deprecated-react-native-prop-types/DeprecatedPointPropType.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedShadowPropTypesIOS.js
+++ b/deprecated-react-native-prop-types/DeprecatedShadowPropTypesIOS.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedStyleSheetPropType.js
+++ b/deprecated-react-native-prop-types/DeprecatedStyleSheetPropType.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedTextInputPropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedTextInputPropTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedTextPropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedTextPropTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedTextStylePropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedTextStylePropTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedTransformPropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedTransformPropTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedViewAccessibility.js
+++ b/deprecated-react-native-prop-types/DeprecatedViewAccessibility.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedViewPropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedViewPropTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/DeprecatedViewStylePropTypes.js
+++ b/deprecated-react-native-prop-types/DeprecatedViewStylePropTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/deprecatedCreateStrictShapeTypeChecker.js
+++ b/deprecated-react-native-prop-types/deprecatedCreateStrictShapeTypeChecker.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deprecated-react-native-prop-types",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Deprecated prop-types from React Native.",
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",


### PR DESCRIPTION
Makes these deprecated packages slightly less annoying to work with in codebases that utilize Flow.