### PR TITLE
[prop-types] Restrict @react-native/normalize-colors dependency to <0.73.0 to avoid requiring Node 18

### DIFF
--- a/deprecated-react-native-prop-types/CHANGELOG.md
+++ b/deprecated-react-native-prop-types/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.2 / 2023-10-12
+
+- Restricted `@react-native/normalize-colors` dependency to `<0.74.0` to avoid a transitive Node >= 18 requirement.
+
 # 4.2.1 / 2023-07-28
 
 - Added `@flow` so all modules can be imported without suppressing [untyped-import]

--- a/deprecated-react-native-prop-types/CHANGELOG.md
+++ b/deprecated-react-native-prop-types/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.2.2 / 2023-10-12
 
-- Restricted `@react-native/normalize-colors` dependency to `<0.74.0` to avoid a transitive Node >= 18 requirement.
+- Restricted `@react-native/normalize-colors` dependency to `<0.73.0` to avoid a transitive Node >= 18 requirement.
 
 # 4.2.1 / 2023-07-28
 

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",
   "dependencies": {
-    "@react-native/normalize-colors": "<0.74.0",
+    "@react-native/normalize-colors": "<0.73.0",
     "invariant": "*",
     "prop-types": "*"
   },

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deprecated-react-native-prop-types",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Deprecated prop-types from React Native.",
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",
   "dependencies": {
-    "@react-native/normalize-colors": "*",
+    "@react-native/normalize-colors": "<0.74.0",
     "invariant": "*",
     "prop-types": "*"
   },

--- a/deprecated-react-native-prop-types/yarn.lock
+++ b/deprecated-react-native-prop-types/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@react-native/normalize-colors@*":
-  version "0.72.0"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.72.0.tgz#14294b7ed3c1d92176d2a00df48456e8d7d62212"
-  integrity sha512-285lfdqSXaqKuBbbtP9qL2tDrfxdOFtIMvkKadtleRQkdOxx+uzGvFr82KHmc/sSiMtfXGp7JnFYWVh4sFl7Yw==
+"@react-native/normalize-colors@<0.74.0":
+  version "0.73.2"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.73.2.tgz#cc8e48fbae2bbfff53e12f209369e8d2e4cf34ec"
+  integrity sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w==
 
 invariant@*:
   version "2.2.4"

--- a/deprecated-react-native-prop-types/yarn.lock
+++ b/deprecated-react-native-prop-types/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@react-native/normalize-colors@<0.74.0":
-  version "0.73.2"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.73.2.tgz#cc8e48fbae2bbfff53e12f209369e8d2e4cf34ec"
-  integrity sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w==
+"@react-native/normalize-colors@<0.73.0":
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.72.0.tgz#14294b7ed3c1d92176d2a00df48456e8d7d62212"
+  integrity sha512-285lfdqSXaqKuBbbtP9qL2tDrfxdOFtIMvkKadtleRQkdOxx+uzGvFr82KHmc/sSiMtfXGp7JnFYWVh4sFl7Yw==
 
 invariant@*:
   version "2.2.4"


### PR DESCRIPTION
`@react-native/normalize-colors` >0.73.0 drops support for Node 16 (and some versions, eg 0.73.1, enforce Node 18 via `package.json#engines`).

Tighten up this dependency to not inadvertently push a transitive breaking change to users without a semver major release.