### PR TITLE
[prop-types] v5.0.0. Use semver range dependencies, drop Node <18.

### DIFF
--- a/deprecated-react-native-prop-types/CHANGELOG.md
+++ b/deprecated-react-native-prop-types/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0 / 2023-10-12
+
+- (Breaking) bump dependency on `@react-native/normalize-colors` to `^0.73.0` - this requires Node >= 18
+- Explicitly require Node >= 18 via `engines`
+
 # 4.2.3 / 2023-10-12
 
 - Use semver ranges for prop-types and invariant deps.

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",
   "dependencies": {
-    "@react-native/normalize-colors": "<0.73.0",
+    "@react-native/normalize-colors": "^0.73.0",
     "invariant": "^2.2.4",
     "prop-types": "^15.8.1"
   },

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -19,5 +19,8 @@
     "bracketSpacing": false,
     "jsxBracketSameLine": true,
     "arrowParens": "avoid"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deprecated-react-native-prop-types",
-  "version": "4.2.3",
+  "version": "5.0.0",
   "description": "Deprecated prop-types from React Native.",
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",

--- a/deprecated-react-native-prop-types/yarn.lock
+++ b/deprecated-react-native-prop-types/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@react-native/normalize-colors@<0.73.0":
-  version "0.72.0"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.72.0.tgz#14294b7ed3c1d92176d2a00df48456e8d7d62212"
-  integrity sha512-285lfdqSXaqKuBbbtP9qL2tDrfxdOFtIMvkKadtleRQkdOxx+uzGvFr82KHmc/sSiMtfXGp7JnFYWVh4sFl7Yw==
+"@react-native/normalize-colors@^0.73.0":
+  version "0.73.2"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.73.2.tgz#cc8e48fbae2bbfff53e12f209369e8d2e4cf34ec"
+  integrity sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w==
 
 invariant@^2.2.4:
   version "2.2.4"


### PR DESCRIPTION
Old releases of React Native pin to a `react-native-deprecated-prop-types` version that in turn depends on `"@react-native/normalize-colors": *`.

This is problematic, because it means breaking changes to RN/NC are automatically pulled in to old RN projects. This has come up twice when we've tried to introduce a Node >=18 requirement to RN/NC, in `0.73.1` and `0.74.0` (https://github.com/facebook/react-native/issues/39692, https://github.com/facebook/react-native/issues/40797).

Let's put a stop to this by capping the prop-types V4 branch at `<0.73.0`, and releasing a v5.0.0 which:
 - Adds a `"node": ">=18"` requirement explicitly mirroring the one in RN.
 - Depends on the range `"@react-native/normalize-colors": "^0.73.0"`. We'll be free to expand this to `"^0.73.0 || ^0.74.0"`, etc, as we confirm compatibility.