### PR TITLE
[prop-types][3.x] Use semver range dependencies, bump to 3.0.2

### DIFF
--- a/deprecated-react-native-prop-types/CHANGELOG.md
+++ b/deprecated-react-native-prop-types/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.1 / 2023-10-12
+- Specify dependencies with semver ranges to avoid picking up transitive breaking changes.
+
 # 3.0.1 / 2022-12-02
 
 - Compatible with React Native 0.71

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deprecated-react-native-prop-types",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Deprecated prop-types from React Native.",
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",

--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "repository": "github:facebook/react-native-deprecated-modules",
   "dependencies": {
-    "@react-native/normalize-color": "*",
-    "invariant": "*",
-    "prop-types": "*"
+    "@react-native/normalize-color": "^2.1.0",
+    "invariant": "^2.2.4",
+    "prop-types": "^15.8.1"
   },
   "scripts": {
     "test": "node -e \"Object.values(require('.'))\""


### PR DESCRIPTION
 - Prevent picking up transitive breaking changes by specifying dependencies with caret ranges.
 - Bump to 3.0.2