### PR TITLE
Remove engine restriction

### DIFF
--- a/deprecated-react-native-prop-types/package.json
+++ b/deprecated-react-native-prop-types/package.json
@@ -19,8 +19,5 @@
     "bracketSpacing": false,
     "jsxBracketSameLine": true,
     "arrowParens": "avoid"
-  },
-  "engines": {
-    "node": ">=18"
   }
 }


### PR DESCRIPTION
Hello!

I'm working with an older React Native application, attempting to upgrade it to more recent versions. I have upgraded Node to v14. I ran into issues with ViewPropTypes when upgrading React Native to 0.69, so I installed this package. Unfortunately the engine requirement here creates a bit of a burden when installing. As far as I can tell, the project works fine on Node 14.

Is there any reason the engine constraint can't be removed?

Thanks!